### PR TITLE
fix(config): harden harness proof validation

### DIFF
--- a/.agents/skills/vrk-mvp-stage-orchestrator/SKILL.md
+++ b/.agents/skills/vrk-mvp-stage-orchestrator/SKILL.md
@@ -41,6 +41,8 @@ Runtime self-check for the active harness is available via:
 python3 .agents/skills/vrk-mvp-stage-orchestrator/scripts/verify_harness.py --stage-id <stage-id>
 ```
 
+The self-check is semantic, not just structural: it validates placeholder-free stage freeze docs, actionable `feature_list.json`, and internal consistency of `evidence.json` / `verdict.json` for the requested stage.
+
 ## Commands supported by this skill
 
 Treat the following phrases as commands when the user invokes this skill:

--- a/.agents/skills/vrk-mvp-stage-orchestrator/scripts/verify_harness.py
+++ b/.agents/skills/vrk-mvp-stage-orchestrator/scripts/verify_harness.py
@@ -8,7 +8,7 @@ import json
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 
 REQUIRED_STAGE_FILES = (
@@ -36,6 +36,14 @@ REQUIRED_UI_LOOKUP_FILES = (
     "docs/design/storybook-component-backlog.md",
     ".agents/skills/vrk-web-ui-workflow/SKILL.md",
     ".agents/skills/vrk-web-ui-workflow/scripts/storybook_component_lookup.py",
+)
+
+VALID_VERDICT_STATUSES = {"PENDING", "FAIL", "PASS"}
+
+PLACEHOLDER_MARKERS = (
+    ("{{", "template placeholder"),
+    ("TBD", "unfinished placeholder"),
+    ("Replace this placeholder", "template placeholder"),
 )
 
 
@@ -94,6 +102,172 @@ def collect_stage_artifacts(stage_dir: Path) -> dict[str, object]:
             if (stage_dir / entry).exists()
         ),
     }
+
+
+def read_json(path: Path) -> tuple[Any | None, str | None]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except FileNotFoundError:
+        return None, f"Missing {path.name}."
+    except json.JSONDecodeError as exc:
+        return None, f"{path.name} is not valid JSON: {exc.msg}."
+
+
+def is_iso_timestamp(value: Any) -> bool:
+    if not isinstance(value, str) or not value.strip():
+        return False
+    candidate = value.replace("Z", "+00:00")
+    try:
+        datetime.fromisoformat(candidate)
+    except ValueError:
+        return False
+    return True
+
+
+def find_placeholder_markers(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    found: list[str] = []
+    for marker, label in PLACEHOLDER_MARKERS:
+        if marker in text:
+            found.append(f"{path.name}: {label} `{marker}`")
+    return found
+
+
+def validate_stage_freeze(stage_dir: Path) -> list[str]:
+    issues: list[str] = []
+    for name in ("stage_spec.md", "sprint_contract.md"):
+        path = stage_dir / name
+        if path.exists():
+            issues.extend(find_placeholder_markers(path))
+    return issues
+
+
+def validate_feature_list(stage_dir: Path, repo_root: Path) -> list[str]:
+    path = stage_dir / "feature_list.json"
+    payload, error = read_json(path)
+    if error:
+        return [error]
+    if not isinstance(payload, list) or not payload:
+        return ["feature_list.json must contain a non-empty JSON array."]
+
+    issues: list[str] = []
+    for index, item in enumerate(payload, start=1):
+        prefix = f"feature_list.json[{index}]"
+        if not isinstance(item, dict):
+            issues.append(f"{prefix} must be an object.")
+            continue
+
+        feature_id = item.get("id")
+        category = item.get("category")
+        description = item.get("description")
+        steps = item.get("steps")
+        passes = item.get("passes")
+        evidence_refs = item.get("evidence_refs")
+
+        if not isinstance(feature_id, str) or not feature_id.strip():
+            issues.append(f"{prefix}.id must be a non-empty string.")
+        elif feature_id == "seed-me":
+            issues.append(f"{prefix}.id still uses the template placeholder `seed-me`.")
+
+        if not isinstance(category, str) or not category.strip():
+            issues.append(f"{prefix}.category must be a non-empty string.")
+
+        if not isinstance(description, str) or not description.strip():
+            issues.append(f"{prefix}.description must be a non-empty string.")
+        elif "Replace this placeholder" in description:
+            issues.append(f"{prefix}.description still contains template text.")
+
+        if not isinstance(steps, list) or not steps:
+            issues.append(f"{prefix}.steps must be a non-empty list of strings.")
+        elif not all(isinstance(step, str) and step.strip() for step in steps):
+            issues.append(f"{prefix}.steps must contain only non-empty strings.")
+
+        if not isinstance(passes, bool):
+            issues.append(f"{prefix}.passes must be a boolean.")
+
+        if not isinstance(evidence_refs, list):
+            issues.append(f"{prefix}.evidence_refs must be a list of repo-relative paths.")
+            continue
+        if not all(isinstance(ref, str) and ref.strip() for ref in evidence_refs):
+            issues.append(f"{prefix}.evidence_refs must contain only non-empty strings.")
+            continue
+        if passes and not evidence_refs:
+            issues.append(f"{prefix} is marked passed but has no evidence_refs.")
+        for ref in evidence_refs:
+            if not (repo_root / ref).exists():
+                issues.append(f"{prefix}.evidence_refs points to a missing path: {ref}")
+
+    return issues
+
+
+def validate_evidence_bundle(stage_dir: Path, repo_root: Path, stage_id: str) -> list[str]:
+    evidence_path = stage_dir / "evidence.json"
+    verdict_path = stage_dir / "verdict.json"
+
+    evidence, evidence_error = read_json(evidence_path)
+    verdict, verdict_error = read_json(verdict_path)
+
+    issues: list[str] = []
+    if evidence_error:
+        issues.append(evidence_error)
+        return issues
+    if verdict_error:
+        issues.append(verdict_error)
+        return issues
+    if not isinstance(evidence, dict):
+        return ["evidence.json must contain a JSON object."]
+    if not isinstance(verdict, dict):
+        return ["verdict.json must contain a JSON object."]
+
+    if evidence.get("stage_id") != stage_id:
+        issues.append(
+            f"evidence.json stage_id must match `{stage_id}`, found `{evidence.get('stage_id')}`."
+        )
+
+    artifacts = evidence.get("artifacts")
+    commands = evidence.get("commands")
+    tests = evidence.get("tests")
+    if not isinstance(commands, list):
+        issues.append("evidence.json.commands must be a list.")
+    if not isinstance(tests, list):
+        issues.append("evidence.json.tests must be a list.")
+    if not isinstance(artifacts, list) or not all(
+        isinstance(artifact, str) and artifact.strip() for artifact in artifacts
+    ):
+        issues.append("evidence.json.artifacts must be a list of repo-relative paths.")
+        artifacts = []
+
+    for artifact in artifacts:
+        if not (repo_root / artifact).exists():
+            issues.append(f"evidence.json.artifacts points to a missing path: {artifact}")
+
+    status = verdict.get("status")
+    if status not in VALID_VERDICT_STATUSES:
+        issues.append(
+            f"verdict.json.status must be one of {sorted(VALID_VERDICT_STATUSES)}, found `{status}`."
+        )
+        return issues
+
+    if status == "PASS":
+        summary = verdict.get("summary")
+        if not isinstance(summary, str) or not summary.strip():
+            issues.append("verdict.json summary must be non-empty when status is PASS.")
+        if not is_iso_timestamp(verdict.get("last_verified_at")):
+            issues.append("verdict.json last_verified_at must be an ISO timestamp when status is PASS.")
+        if not is_iso_timestamp(evidence.get("updated_at")):
+            issues.append("evidence.json updated_at must be an ISO timestamp when verdict status is PASS.")
+        if not artifacts:
+            issues.append("evidence.json must list artifacts when verdict status is PASS.")
+        if not commands:
+            issues.append("evidence.json must list commands when verdict status is PASS.")
+        if not tests:
+            issues.append("evidence.json must list tests when verdict status is PASS.")
+        if verdict.get("failed_criteria"):
+            issues.append("verdict.json failed_criteria must be empty when status is PASS.")
+        if verdict.get("proof_gaps"):
+            issues.append("verdict.json proof_gaps must be empty when status is PASS.")
+
+    return issues
 
 
 def main() -> None:
@@ -219,6 +393,43 @@ def main() -> None:
             else f"Stage artifacts are incomplete for {args.stage_id}: {stage_artifacts['missing']}",
         )
     )
+
+    if stage_artifacts["exists"] and not stage_artifacts["missing"]:
+        stage_freeze_issues = validate_stage_freeze(stage_dir)
+        checks.append(
+            CheckResult(
+                id="stage-freeze",
+                status="PASS" if not stage_freeze_issues else "FAIL",
+                detail=f"Stage spec and sprint contract are frozen for {args.stage_id}."
+                if not stage_freeze_issues
+                else "Stage freeze artifacts still contain placeholders: "
+                + "; ".join(stage_freeze_issues),
+            )
+        )
+
+        feature_list_issues = validate_feature_list(stage_dir, repo_root)
+        checks.append(
+            CheckResult(
+                id="feature-list-quality",
+                status="PASS" if not feature_list_issues else "FAIL",
+                detail=f"feature_list.json is actionable for {args.stage_id}."
+                if not feature_list_issues
+                else "feature_list.json has semantic gaps: "
+                + "; ".join(feature_list_issues),
+            )
+        )
+
+        proof_bundle_issues = validate_evidence_bundle(stage_dir, repo_root, args.stage_id)
+        checks.append(
+            CheckResult(
+                id="proof-bundle-consistency",
+                status="PASS" if not proof_bundle_issues else "FAIL",
+                detail=f"evidence.json and verdict.json are internally consistent for {args.stage_id}."
+                if not proof_bundle_issues
+                else "Proof bundle has semantic gaps: "
+                + "; ".join(proof_bundle_issues),
+            )
+        )
 
     overall_status = "PASS" if all(check.status == "PASS" for check in checks) else "FAIL"
 

--- a/.agents/skills/vrk-mvp-stage-orchestrator/tests/test_verify_harness.py
+++ b/.agents/skills/vrk-mvp-stage-orchestrator/tests/test_verify_harness.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "verify_harness.py"
+SPEC = importlib.util.spec_from_file_location("verify_harness", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC is not None and SPEC.loader is not None
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+class VerifyHarnessSemanticChecksTest(unittest.TestCase):
+    def test_stage_freeze_detects_placeholders(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            stage_dir = Path(tmp)
+            write(stage_dir / "stage_spec.md", "# Stage Spec\n\n## Objective\n\nTBD\n")
+            write(stage_dir / "sprint_contract.md", "# Sprint Contract\n\n## Objective\n\n{{OBJECTIVE}}\n")
+
+            issues = MODULE.validate_stage_freeze(stage_dir)
+
+            self.assertTrue(any("stage_spec.md" in issue for issue in issues))
+            self.assertTrue(any("sprint_contract.md" in issue for issue in issues))
+
+    def test_feature_list_requires_steps_and_evidence_for_passed_items(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            stage_dir = repo_root / ".agent" / "stages" / "03-identity-master-data"
+            stage_dir.mkdir(parents=True, exist_ok=True)
+            write(
+                stage_dir / "feature_list.json",
+                json.dumps(
+                    [
+                        {
+                            "id": "stage03-shell",
+                            "category": "functional",
+                            "description": "Proof-bearing feature.",
+                            "steps": [],
+                            "passes": True,
+                            "evidence_refs": [],
+                        }
+                    ]
+                ),
+            )
+
+            issues = MODULE.validate_feature_list(stage_dir, repo_root)
+
+            self.assertIn(
+                "feature_list.json[1].steps must be a non-empty list of strings.",
+                issues,
+            )
+            self.assertIn(
+                "feature_list.json[1] is marked passed but has no evidence_refs.",
+                issues,
+            )
+
+    def test_proof_bundle_checks_stage_id_and_artifact_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp)
+            stage_dir = repo_root / ".agent" / "stages" / "02-platform-foundation"
+            stage_dir.mkdir(parents=True, exist_ok=True)
+            write(
+                stage_dir / "evidence.json",
+                json.dumps(
+                    {
+                        "stage_id": "wrong-stage",
+                        "commands": ["python3 verify_harness.py"],
+                        "tests": ["PASS"],
+                        "artifacts": [".agent/stages/02-platform-foundation/raw/missing.txt"],
+                        "updated_at": "2026-04-18T18:07:50Z",
+                    }
+                ),
+            )
+            write(
+                stage_dir / "verdict.json",
+                json.dumps(
+                    {
+                        "status": "PASS",
+                        "summary": "Bundle passed.",
+                        "failed_criteria": [],
+                        "proof_gaps": [],
+                        "last_verified_at": "2026-04-18T18:07:50Z",
+                    }
+                ),
+            )
+
+            issues = MODULE.validate_evidence_bundle(
+                stage_dir, repo_root, "02-platform-foundation"
+            )
+
+            self.assertIn(
+                "evidence.json stage_id must match `02-platform-foundation`, found `wrong-stage`.",
+                issues,
+            )
+            self.assertIn(
+                "evidence.json.artifacts points to a missing path: .agent/stages/02-platform-foundation/raw/missing.txt",
+                issues,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/testing/test-strategy.md
+++ b/docs/testing/test-strategy.md
@@ -34,6 +34,7 @@
 Для Stage 00 обязательны:
 
 - runtime self-check через `python3 .agents/skills/vrk-mvp-stage-orchestrator/scripts/verify_harness.py --stage-id 00-harness-and-source-of-truth`;
+- runtime self-check должен подтверждать не только layout harness, но и semantic readiness stage bundle: без template placeholders в `stage_spec.md` / `sprint_contract.md`, с actionable `feature_list.json` и консистентными `evidence.json` / `verdict.json`;
 - проверка наличия `AGENTS.md`, `.agents/skills`, `.codex/agents`, `.codex/config.toml`;
 - проверка существования `.agent/stages/00..07`;
 - проверка, что source-of-truth, ADR и stage artifacts реально созданы.


### PR DESCRIPTION
## Цель
- `verify_harness.py` подтверждал только layout stage bundle и мог давать `PASS` даже для seeded placeholder стадий
- убрать ложное ощущение proof integrity там, где раньше проверялась только структура файлов

## Что сделано
- добавлена semantic-проверка `stage_spec.md` и `sprint_contract.md` на template placeholders
- добавлена проверка `feature_list.json` на actionable shape, placeholder-поля и `passes=true` без `evidence_refs`
- добавлена проверка консистентности `evidence.json` и `verdict.json`: `stage_id`, enum статуса, timestamps и существование artifact paths
- добавлены узкие unit tests на новые проверки
- обновлены docs рядом с harness, чтобы self-check явно описывался как semantic, а не только structural

## Как проверить
- `python3 .agents/skills/vrk-mvp-stage-orchestrator/tests/test_verify_harness.py`
- `python3 .agents/skills/vrk-mvp-stage-orchestrator/scripts/verify_harness.py --stage-id 00-harness-and-source-of-truth`
- `python3 .agents/skills/vrk-mvp-stage-orchestrator/scripts/verify_harness.py --stage-id 04-request-core-and-customer-cabinet`
- ожидаемо: Stage 00 проходит, seeded placeholder Stage 04 падает на `stage-freeze` и `feature-list-quality`

## Риски и примечания
- проверка пока не пытается механически доказывать freshness verifier session: в текущих artifacts для этого нет достаточной provenance-модели
- проверка не лезет в жёсткие git-cleanliness инварианты, чтобы не ломать обычный runtime self-check на живой разработке
- scope PR намеренно ограничен harness validation и сопутствующим doc/test sync

## Скриншоты
- не применимо
