### PR TITLE
Add VRK DB on-demand cloud function controls

### DIFF
--- a/apps/backend/internal/app/app.go
+++ b/apps/backend/internal/app/app.go
@@ -47,7 +47,7 @@ func New(cfg *config.Config) (*App, error) {
 	}
 
 	logger.Info(
-		"database_ready",
+		"database_pool_configured",
 		"database", cfg.Database.DBName,
 		"host", cfg.Database.Host,
 		"port", cfg.Database.Port,

--- a/apps/backend/internal/infrastructure/db/db.go
+++ b/apps/backend/internal/infrastructure/db/db.go
@@ -1,38 +1,35 @@
 package db
 
 import (
-    "context"
-    "fmt"
-    "time"
+	"context"
+	"fmt"
+	"time"
 
-    "github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
-    config, err := pgxpool.ParseConfig(dsn)
-    if err != nil {
-        return nil, fmt.Errorf("failed to parse DSN: %w", err)
-    }
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse DSN: %w", err)
+	}
 
-    config.MaxConns = 25
-    config.MinConns = 5
-    config.MaxConnLifetime = 5 * time.Minute
-    config.MaxConnIdleTime = 1 * time.Minute
+	config.MaxConns = 25
+	config.MinConns = 0
+	config.MaxConnLifetime = 5 * time.Minute
+	config.MaxConnIdleTime = 1 * time.Minute
+	config.ConnConfig.ConnectTimeout = 5 * time.Second
 
-    pool, err := pgxpool.NewWithConfig(ctx, config)
-    if err != nil {
-        return nil, fmt.Errorf("failed to create pool: %w", err)
-    }
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pool: %w", err)
+	}
 
-    if err := pool.Ping(ctx); err != nil {
-        return nil, fmt.Errorf("failed to ping database: %w", err)
-    }
-
-    return pool, nil
+	return pool, nil
 }
 
 func Close(pool *pgxpool.Pool) {
-    if pool != nil {
-        pool.Close()
-    }
+	if pool != nil {
+		pool.Close()
+	}
 }

--- a/docs/architecture/platform-runtime-baseline.md
+++ b/docs/architecture/platform-runtime-baseline.md
@@ -31,6 +31,7 @@
 - `make smoke` требует доступный `python3` в локальном shell;
 - `make down` сохраняет named Postgres volume и marker успешного dev seed, а `make clean` пересоздает clean-room baseline для повторного seeded proof;
 - backend build/test path доступен через контейнерные scripts и не требует локального `go`.
+- backend создает PostgreSQL pool на startup без обязательного `Ping`, поэтому `/healthz` отражает liveness HTTP-процесса, а `/readyz` выполняет bounded DB ping и остается source of truth для готовности базы;
 - `compose.dev.yml` является официальным dev overlay для hot reload `apps/web`: он переиспользует `db`, `migrate`, `backend` и published port `3100` из `compose.platform.yml`, но запускает `web` через `pnpm --filter @vrk/web dev --hostname 0.0.0.0 --port 3000`;
 - root `make web-dev` поднимает тот же overlay для локальной UI-разработки, не заменяя production-like `make dev` / `make smoke` contract.
 

--- a/docs/architecture/yandex-cloud-incubator-deployment.md
+++ b/docs/architecture/yandex-cloud-incubator-deployment.md
@@ -100,6 +100,8 @@ flowchart LR
 
 The workflow is intentionally ordered so migrations complete before the backend revision is deployed, and the web revision is deployed only after the backend revision succeeds. The backend container receives S3-compatible Yandex Object Storage settings for organization logos. The web container receives `INTERNAL_API_BASE_URL` and `NEXT_PUBLIC_API_BASE_URL` from `VRK_BACKEND_URL`; it also receives a derived `NEXT_PUBLIC_STORYBOOK_URL=${VRK_WEB_URL}/storybook/` and serves the static Storybook build from the same public endpoint.
 
+Backend startup configures the PostgreSQL pool without blocking the HTTP process on an initial DB ping. In the incubator scale-to-zero topology this keeps `/healthz` responsive while `vrk-db` is still starting; `/readyz` remains the readiness gate because it performs the bounded database ping used by CI and operator checks.
+
 Do not set `PORT` in Serverless Container revision env. Yandex Cloud reserves this environment variable and rejects web revision deployment with `INVALID_ARGUMENT: Environment variable PORT is forbidden`. The incubator web image starts Next.js on `${PORT:-8080}` through `apps/web/Dockerfile`; local Compose sets `PORT=3000`, while Yandex Cloud reaches the container on `127.0.0.1:8080`.
 
 For session-authenticated backend calls in this Serverless Container topology, prefer `X-VRK-Session-Token` over the standard `Authorization` header. The public Yandex endpoint can reserve `Authorization` for cloud invocation auth before the request reaches the container. The backend remains backward-compatible with `Authorization: Bearer <token>` for local Compose and direct backend tests, while the web server proxy and dev seed use `X-VRK-Session-Token` for Incubator runtime calls.

--- a/docs/operations/yandex-cloud-vrk-db-control.md
+++ b/docs/operations/yandex-cloud-vrk-db-control.md
@@ -1,0 +1,52 @@
+# Yandex Cloud VRK DB Control
+
+`vrk-db` is intentionally on-demand. The public start function opens a 6-hour window, and the timer-driven autostop function closes the database after the `active_until` label expires.
+
+This control path is cloud-only. There is no local repository script for starting or extending `vrk-db`.
+
+## Resources
+
+- Folder: `vrk` (`b1g5et00t4pvrfoetdtc`)
+- PostgreSQL cluster: `vrk-db` (`c9qf8h0188hb4jolntie`)
+- Runtime service account: `vrk-db-control-sa`
+- Public start function: `vrk-db-start`
+- Timer function: `vrk-db-autostop`
+- Timer trigger: `vrk-db-autostop-15m`
+- Source: `infra/yandex-cloud/vrk-db-control/index.py`
+
+## Public Start URL
+
+`GET https://functions.yandexcloud.net/d4ess1jd8mb1sqgk454l` starts or extends the DB session for 6 hours. The URL is intentionally public and unauthenticated, so anyone with the URL can trigger a DB start.
+
+The start function uses the `start` handler. It starts the PostgreSQL cluster when it is stopped, waits for the cluster to become `RUNNING`, and writes these labels:
+
+- `active_until`: Unix timestamp for the current session expiry.
+- `managed_by`: `vrk-db-control`.
+
+Calling the URL again extends `active_until` by another 6 hours from the call time.
+
+## Autostop
+
+The timer trigger invokes `vrk-db-autostop` every 15 minutes. If `vrk-db` is not stopped and `active_until` is missing or expired, the function sends a stop operation.
+
+The autostop function uses the `autostop` handler. It does nothing while the cluster is stopped, in a transient status, or inside the active session window.
+
+```mermaid
+flowchart LR
+    A["GET public start URL"] --> B["Start or confirm vrk-db is running"]
+    B --> C["Set active_until = now + 6h"]
+    D["15m timer trigger"] --> E["Read cluster labels"]
+    E --> F{"active_until still valid?"}
+    F -->|yes| G["Noop"]
+    F -->|no or missing| H["Stop vrk-db"]
+```
+
+## Runtime Configuration
+
+Both functions read configuration from environment variables:
+
+- `VRK_DB_CLUSTER_ID`: required Yandex Managed PostgreSQL cluster ID.
+- `VRK_DB_SESSION_HOURS`: optional session length, defaults to `6`.
+- `VRK_DB_OPERATION_WAIT_SECONDS`: optional operation wait timeout, defaults to `240`.
+
+The function runtime gets an IAM token from the Yandex Cloud metadata service through `vrk-db-control-sa`; no Lockbox payload or local `.env` file is required for the control path.

--- a/docs/operations/yandex-cloud-vrk-db-control.md
+++ b/docs/operations/yandex-cloud-vrk-db-control.md
@@ -18,12 +18,29 @@ This control path is cloud-only. There is no local repository script for startin
 
 `GET https://functions.yandexcloud.net/d4ess1jd8mb1sqgk454l` starts or extends the DB session for 6 hours. The URL is intentionally public and unauthenticated, so anyone with the URL can trigger a DB start.
 
-The start function uses the `start` handler. It starts the PostgreSQL cluster when it is stopped, waits for the cluster to become `RUNNING`, and writes these labels:
+The start function uses the `start` handler. It opens or extends the runtime lease and returns a bounded JSON response instead of keeping the browser request open until the PostgreSQL cluster fully boots.
+
+Response contract:
+
+- `200` with `action=extend-requested`: the cluster is already `RUNNING`; the function requested a lease-label extension.
+- `202` with `action=start-requested`: the cluster was `STOPPED`; the function wrote the lease label and requested a start operation. Backend readiness may still take a few minutes.
+- `202` with `action=cluster-operation-in-progress`: Yandex Cloud already reports `STARTING` or `UPDATING`; poll backend `/readyz`.
+- `409` with `action=unsupported-status`: the cluster is in a status that the public start URL should not mutate.
+
+The lease labels are:
 
 - `active_until`: Unix timestamp for the current session expiry.
 - `managed_by`: `vrk-db-control`.
 
 Calling the URL again extends `active_until` by another 6 hours from the call time.
+
+After `action=start-requested`, check backend readiness with:
+
+```bash
+curl -i https://bbann5sjkg8iha0mmsl3.containers.yandexcloud.net/readyz
+```
+
+`/healthz` only proves the backend HTTP process is alive. `/readyz` is the source of truth for database availability.
 
 ## Autostop
 
@@ -33,12 +50,19 @@ The autostop function uses the `autostop` handler. It does nothing while the clu
 
 ```mermaid
 flowchart LR
-    A["GET public start URL"] --> B["Start or confirm vrk-db is running"]
-    B --> C["Set active_until = now + 6h"]
-    D["15m timer trigger"] --> E["Read cluster labels"]
-    E --> F{"active_until still valid?"}
-    F -->|yes| G["Noop"]
-    F -->|no or missing| H["Stop vrk-db"]
+    StartUrl["GET public start URL"] --> DbStatus{"vrk-db status"}
+    DbStatus -->|STOPPED| Lease["Set active_until lease label"]
+    Lease --> StartOp["Request DB start operation"]
+    DbStatus -->|RUNNING| Extend["Request lease-label extension"]
+    DbStatus -->|STARTING / UPDATING| InProgress["Return 202 operation in progress"]
+    StartOp --> ReadyPoll["Poll backend /readyz"]
+    Extend --> ReadyPoll
+    InProgress --> ReadyPoll
+
+    Timer["15m timer trigger"] --> ReadLabels["Read cluster labels"]
+    ReadLabels --> LeaseValid{"active_until still valid?"}
+    LeaseValid -->|yes| Noop["Noop"]
+    LeaseValid -->|no or missing| StopDb["Stop vrk-db"]
 ```
 
 ## Runtime Configuration
@@ -48,5 +72,6 @@ Both functions read configuration from environment variables:
 - `VRK_DB_CLUSTER_ID`: required Yandex Managed PostgreSQL cluster ID.
 - `VRK_DB_SESSION_HOURS`: optional session length, defaults to `6`.
 - `VRK_DB_OPERATION_WAIT_SECONDS`: optional operation wait timeout, defaults to `240`.
+- `VRK_DB_LABEL_WAIT_SECONDS`: optional short wait for the lease-label operation before requesting cluster start, defaults to `45`.
 
 The function runtime gets an IAM token from the Yandex Cloud metadata service through `vrk-db-control-sa`; no Lockbox payload or local `.env` file is required for the control path.

--- a/infra/yandex-cloud/vrk-db-control/index.py
+++ b/infra/yandex-cloud/vrk-db-control/index.py
@@ -15,6 +15,7 @@ METADATA_TOKEN_URL = (
 
 DEFAULT_SESSION_HOURS = 6
 DEFAULT_OPERATION_WAIT_SECONDS = 240
+DEFAULT_LABEL_WAIT_SECONDS = 45
 DEFAULT_OPERATION_POLL_SECONDS = 5
 
 
@@ -29,38 +30,111 @@ def start(event, context):
     config = _load_config()
     cluster = _get_cluster(config)
     active_until = int(time.time()) + config["session_seconds"]
-
-    start_operation = None
-    if cluster.get("status") == "STOPPED":
-        start_operation = _post_cluster_action(config, "start")
-        _wait_operation(config, start_operation["id"])
-        cluster = _wait_cluster_ready(config)
-    elif cluster.get("status") in {"STARTING", "UPDATING"}:
-        cluster = _wait_cluster_ready(config)
+    status = cluster.get("status")
 
     labels = _merged_labels(cluster, active_until)
-    label_operation = _update_labels(config, labels)
-    label_result = _wait_operation(config, label_operation["id"])
-    cluster = _get_cluster(config)
-
-    if cluster.get("status") in {"STARTING", "UPDATING"}:
-        cluster = _wait_cluster_ready(config)
-
-    body = {
+    base_body = {
         "ok": True,
-        "action": "start-or-extend",
         "cluster_id": config["cluster_id"],
         "cluster_name": cluster.get("name"),
-        "status": cluster.get("status"),
+        "status_before": status,
         "health": cluster.get("health"),
         "active_until": active_until,
         "active_until_iso": _format_epoch(active_until),
         "session_hours": config["session_seconds"] // 3600,
-        "label_operation_id": label_operation["id"],
-        "label_operation_done": label_result.get("done", False),
-        "start_operation_id": start_operation["id"] if start_operation else None,
     }
-    return _response(200, body)
+
+    try:
+        if status == "STOPPED":
+            label_operation = _update_labels(config, labels)
+            label_result = _wait_operation(
+                config,
+                label_operation["id"],
+                timeout_seconds=config["label_wait_seconds"],
+            )
+            if not label_result.get("done"):
+                return _response(
+                    202,
+                    {
+                        **base_body,
+                        "action": "lease-update-in-progress",
+                        "label_operation_id": label_operation["id"],
+                        "label_operation_done": False,
+                        "start_operation_id": None,
+                        "message": "Lease label update is still running; retry the start URL in a minute.",
+                    },
+                )
+
+            start_operation = _post_cluster_action(config, "start")
+            return _response(
+                202,
+                {
+                    **base_body,
+                    "action": "start-requested",
+                    "status": "STARTING",
+                    "label_operation_id": label_operation["id"],
+                    "label_operation_done": True,
+                    "start_operation_id": start_operation["id"],
+                    "message": "Database start was requested. Backend readiness may take a few minutes.",
+                },
+            )
+
+        if status == "RUNNING":
+            label_operation = _update_labels(config, labels)
+            return _response(
+                200,
+                {
+                    **base_body,
+                    "action": "extend-requested",
+                    "status": status,
+                    "label_operation_id": label_operation["id"],
+                    "label_operation_done": False,
+                    "start_operation_id": None,
+                    "message": "Database is already running; session extension was requested.",
+                },
+            )
+
+        if status in {"STARTING", "UPDATING"}:
+            current_active_until = _parse_int((cluster.get("labels") or {}).get("active_until"))
+            return _response(
+                202,
+                {
+                    **base_body,
+                    "action": "cluster-operation-in-progress",
+                    "reason": "cluster-operation-in-progress",
+                    "status": status,
+                    "current_active_until": current_active_until,
+                    "current_active_until_iso": _format_epoch(current_active_until)
+                    if current_active_until
+                    else None,
+                    "label_operation_id": None,
+                    "label_operation_done": False,
+                    "start_operation_id": None,
+                    "message": "Cluster operation is already in progress. Check backend /readyz in a few minutes.",
+                },
+            )
+
+        return _response(
+            409,
+            {
+                **base_body,
+                "ok": False,
+                "action": "unsupported-status",
+                "status": status,
+                "message": "Cluster is not in a startable status.",
+            },
+        )
+    except ApiError as err:
+        return _response(
+            err.status if 400 <= err.status < 500 else 502,
+            {
+                **base_body,
+                "ok": False,
+                "action": "api-error",
+                "status": status,
+                "error": err.body,
+            },
+        )
 
 
 def autostop(event, context):
@@ -137,10 +211,15 @@ def _load_config():
     if wait_seconds is None:
         wait_seconds = DEFAULT_OPERATION_WAIT_SECONDS
 
+    label_wait_seconds = _parse_int(os.environ.get("VRK_DB_LABEL_WAIT_SECONDS"))
+    if label_wait_seconds is None:
+        label_wait_seconds = DEFAULT_LABEL_WAIT_SECONDS
+
     return {
         "cluster_id": cluster_id,
         "session_seconds": session_hours * 3600,
         "wait_seconds": wait_seconds,
+        "label_wait_seconds": label_wait_seconds,
         "token": _get_iam_token(),
     }
 
@@ -188,8 +267,9 @@ def _post_cluster_action(config, action):
     )
 
 
-def _wait_operation(config, operation_id):
-    deadline = time.time() + config["wait_seconds"]
+def _wait_operation(config, operation_id, timeout_seconds=None):
+    wait_seconds = config["wait_seconds"] if timeout_seconds is None else timeout_seconds
+    deadline = time.time() + wait_seconds
     last_payload = None
 
     while time.time() < deadline:
@@ -205,19 +285,6 @@ def _wait_operation(config, operation_id):
         time.sleep(DEFAULT_OPERATION_POLL_SECONDS)
 
     return last_payload or {"done": False}
-
-
-def _wait_cluster_ready(config):
-    deadline = time.time() + config["wait_seconds"]
-    last_cluster = None
-
-    while time.time() < deadline:
-        last_cluster = _get_cluster(config)
-        if last_cluster.get("status") == "RUNNING":
-            return last_cluster
-        time.sleep(DEFAULT_OPERATION_POLL_SECONDS)
-
-    return last_cluster or _get_cluster(config)
 
 
 def _request_json(config, method, url, payload=None):

--- a/infra/yandex-cloud/vrk-db-control/index.py
+++ b/infra/yandex-cloud/vrk-db-control/index.py
@@ -1,0 +1,271 @@
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+
+API_BASE = "https://mdb.api.cloud.yandex.net/managed-postgresql/v1"
+OPERATION_BASE = "https://operation.api.cloud.yandex.net/operations"
+METADATA_TOKEN_URL = (
+    "http://169.254.169.254/computeMetadata/v1/instance/"
+    "service-accounts/default/token"
+)
+
+DEFAULT_SESSION_HOURS = 6
+DEFAULT_OPERATION_WAIT_SECONDS = 240
+DEFAULT_OPERATION_POLL_SECONDS = 5
+
+
+class ApiError(Exception):
+    def __init__(self, status: int, body: str):
+        super().__init__(f"Yandex Cloud API error {status}: {body}")
+        self.status = status
+        self.body = body
+
+
+def start(event, context):
+    config = _load_config()
+    cluster = _get_cluster(config)
+    active_until = int(time.time()) + config["session_seconds"]
+
+    start_operation = None
+    if cluster.get("status") == "STOPPED":
+        start_operation = _post_cluster_action(config, "start")
+        _wait_operation(config, start_operation["id"])
+        cluster = _wait_cluster_ready(config)
+    elif cluster.get("status") in {"STARTING", "UPDATING"}:
+        cluster = _wait_cluster_ready(config)
+
+    labels = _merged_labels(cluster, active_until)
+    label_operation = _update_labels(config, labels)
+    label_result = _wait_operation(config, label_operation["id"])
+    cluster = _get_cluster(config)
+
+    if cluster.get("status") in {"STARTING", "UPDATING"}:
+        cluster = _wait_cluster_ready(config)
+
+    body = {
+        "ok": True,
+        "action": "start-or-extend",
+        "cluster_id": config["cluster_id"],
+        "cluster_name": cluster.get("name"),
+        "status": cluster.get("status"),
+        "health": cluster.get("health"),
+        "active_until": active_until,
+        "active_until_iso": _format_epoch(active_until),
+        "session_hours": config["session_seconds"] // 3600,
+        "label_operation_id": label_operation["id"],
+        "label_operation_done": label_result.get("done", False),
+        "start_operation_id": start_operation["id"] if start_operation else None,
+    }
+    return _response(200, body)
+
+
+def autostop(event, context):
+    config = _load_config()
+    cluster = _get_cluster(config)
+    labels = cluster.get("labels") or {}
+    active_until = _parse_int(labels.get("active_until"))
+    now = int(time.time())
+
+    if cluster.get("status") == "STOPPED":
+        return _response(
+            200,
+            {
+                "ok": True,
+                "action": "noop",
+                "reason": "already-stopped",
+                "status": cluster.get("status"),
+                "active_until": active_until,
+            },
+        )
+
+    if cluster.get("status") != "RUNNING":
+        return _response(
+            200,
+            {
+                "ok": True,
+                "action": "noop",
+                "reason": "transient-status",
+                "status": cluster.get("status"),
+                "health": cluster.get("health"),
+                "active_until": active_until,
+            },
+        )
+
+    if active_until is not None and active_until > now:
+        return _response(
+            200,
+            {
+                "ok": True,
+                "action": "noop",
+                "reason": "session-active",
+                "status": cluster.get("status"),
+                "health": cluster.get("health"),
+                "active_until": active_until,
+                "active_until_iso": _format_epoch(active_until),
+                "seconds_left": active_until - now,
+            },
+        )
+
+    stop_operation = _post_cluster_action(config, "stop")
+    return _response(
+        200,
+        {
+            "ok": True,
+            "action": "stop",
+            "reason": "expired-or-missing-active-until",
+            "status_before": cluster.get("status"),
+            "active_until": active_until,
+            "stop_operation_id": stop_operation["id"],
+        },
+    )
+
+
+def _load_config():
+    cluster_id = os.environ.get("VRK_DB_CLUSTER_ID")
+    if not cluster_id:
+        raise RuntimeError("VRK_DB_CLUSTER_ID is required")
+
+    session_hours = _parse_int(os.environ.get("VRK_DB_SESSION_HOURS"))
+    if session_hours is None:
+        session_hours = DEFAULT_SESSION_HOURS
+
+    wait_seconds = _parse_int(os.environ.get("VRK_DB_OPERATION_WAIT_SECONDS"))
+    if wait_seconds is None:
+        wait_seconds = DEFAULT_OPERATION_WAIT_SECONDS
+
+    return {
+        "cluster_id": cluster_id,
+        "session_seconds": session_hours * 3600,
+        "wait_seconds": wait_seconds,
+        "token": _get_iam_token(),
+    }
+
+
+def _get_iam_token():
+    req = urllib.request.Request(
+        METADATA_TOKEN_URL,
+        headers={"Metadata-Flavor": "Google"},
+        method="GET",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        payload = json.loads(resp.read().decode("utf-8"))
+    token = payload.get("access_token")
+    if not token:
+        raise RuntimeError("Metadata service did not return access_token")
+    return token
+
+
+def _get_cluster(config):
+    return _request_json(
+        config,
+        "GET",
+        f"{API_BASE}/clusters/{config['cluster_id']}",
+    )
+
+
+def _update_labels(config, labels):
+    return _request_json(
+        config,
+        "PATCH",
+        f"{API_BASE}/clusters/{config['cluster_id']}",
+        {
+            "updateMask": "labels",
+            "labels": labels,
+        },
+    )
+
+
+def _post_cluster_action(config, action):
+    return _request_json(
+        config,
+        "POST",
+        f"{API_BASE}/clusters/{config['cluster_id']}:{action}",
+        {},
+    )
+
+
+def _wait_operation(config, operation_id):
+    deadline = time.time() + config["wait_seconds"]
+    last_payload = None
+
+    while time.time() < deadline:
+        last_payload = _request_json(
+            config,
+            "GET",
+            f"{OPERATION_BASE}/{operation_id}",
+        )
+        if last_payload.get("done"):
+            if "error" in last_payload:
+                raise RuntimeError(json.dumps(last_payload["error"], ensure_ascii=False))
+            return last_payload
+        time.sleep(DEFAULT_OPERATION_POLL_SECONDS)
+
+    return last_payload or {"done": False}
+
+
+def _wait_cluster_ready(config):
+    deadline = time.time() + config["wait_seconds"]
+    last_cluster = None
+
+    while time.time() < deadline:
+        last_cluster = _get_cluster(config)
+        if last_cluster.get("status") == "RUNNING":
+            return last_cluster
+        time.sleep(DEFAULT_OPERATION_POLL_SECONDS)
+
+    return last_cluster or _get_cluster(config)
+
+
+def _request_json(config, method, url, payload=None):
+    data = None
+    headers = {
+        "Authorization": f"Bearer {config['token']}",
+        "Content-Type": "application/json",
+    }
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8")
+        raise ApiError(exc.code, body) from exc
+
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def _merged_labels(cluster, active_until):
+    labels = dict(cluster.get("labels") or {})
+    labels["active_until"] = str(active_until)
+    labels["managed_by"] = "vrk-db-control"
+    return labels
+
+
+def _response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json; charset=utf-8"},
+        "isBase64Encoded": False,
+        "body": json.dumps(body, ensure_ascii=False),
+    }
+
+
+def _parse_int(value):
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _format_epoch(value):
+    return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()


### PR DESCRIPTION
## Summary

- Adds the Yandex Cloud Functions source for cloud-only on-demand `vrk-db` control.
- Changes the public start URL contract so it returns bounded JSON (`extend-requested`, `start-requested`, or `cluster-operation-in-progress`) instead of keeping the browser request open while Managed PostgreSQL boots.
- Updates backend startup so the HTTP process no longer blocks on an initial DB ping; `/healthz` stays liveness-only and `/readyz` remains the DB readiness gate.
- Documents the public start URL, autostop trigger, runtime configuration, and readiness checks for the incubator environment.

## Root Cause

- `vrk-db-start` waited for the full PostgreSQL start operation, which produced long-running requests and browser loaders.
- Backend cold start also required `db.Ping()` before `ListenAndServe`, so when the DB was stopped or starting the container did not listen on `/healthz` or `/readyz`, and web login surfaced `Backend request failed`.

## Live Update

- Deployed Cloud Function `$latest`: `d4etangvhqgorssu38nn`.
- Deployed backend revision: `bbaqe8iugfqllolacro5` using image `cr.yandex/crp2drtpijno96mlo81b/vrk-backend:codex-db-startup-20260503`.

## Checks

- `python3 -m py_compile infra/yandex-cloud/vrk-db-control/index.py`
- `docker run --rm -v /Users/elena/cursor/vrk:/workspace -w /workspace/apps/backend golang:1.26-alpine sh -lc '/usr/local/go/bin/gofmt -w internal/infrastructure/db/db.go internal/app/app.go && /usr/local/go/bin/go build -buildvcs=false ./...'`
- `./scripts/backend_go_test.sh`
- `git diff --check`
- Live `GET https://functions.yandexcloud.net/d4ess1jd8mb1sqgk454l` returns `200 action=extend-requested`.
- Live backend `/healthz` and `/readyz` return `200`.
- Live web login proxy with invalid credentials returns `401 invalid email or password` instead of `Backend request failed`.
